### PR TITLE
- fixed SSDT-USB-8x70 based on tests with EliteBook 8570p, normal dock and advanced dock

### DIFF
--- a/hotpatch/SSDT-USB-8x70.asl
+++ b/hotpatch/SSDT-USB-8x70.asl
@@ -31,20 +31,24 @@
                 "port-count", Buffer() { 8, 0, 0, 0 },
                 "ports", Package()
                 {
-                    "HP11", Package()   // unknown USB2 (on dock?)
-                    {
-                        //"UsbConnector", 3,
-                        "port", Buffer() { 1, 0, 0, 0 },
-                    },
-                    //HP12 not used
-                    "HP13", Package()   // HS USB3 left
-                    {
-                        //"UsbConnector", 3,
-                        "port", Buffer() { 3, 0, 0, 0 },
-                    },
-                    "HP14", Package()   // HS USB3 left
+                    "HP11", Package()   // USB2 hub (on normal dock and advanced dock)
                     {
                         //"UsbConnector", 0,
+                        "port", Buffer() { 1, 0, 0, 0 },
+                    },
+                    "HP12", Package()   // near display USB2 left
+                    {
+                        //"UsbConnector", 0,
+                        "port", Buffer() { 2, 0, 0, 0 },
+                    },
+                    "HP13", Package()   // near display USB3 right
+                    {
+                        //"UsbConnector", 0,
+                        "port", Buffer() { 3, 0, 0, 0 },
+                    },
+                    "HP14", Package()   // far display USB3 right
+                    {
+                        //"UsbConnector", 3,
                         "port", Buffer() { 4, 0, 0, 0 },
                     },
                     "HP16", Package()   // bluetooth
@@ -82,7 +86,7 @@
                         "port", Buffer() { 1, 0, 0, 0 },
                     },
                     #endif
-                    "HP22", Package()   // USB2 right
+                    "HP22", Package()   // far display USB2 left
                     {
                         //"UsbConnector", 0,
                         "port", Buffer() { 2, 0, 0, 0 },
@@ -94,12 +98,12 @@
                         //"portType", 4,  // fix for camera after sleep?
                         "port", Buffer() { 3, 0, 0, 0 },
                     },
-                    "HP24", Package()   // unknown USB2 port with hub (dock?)
+                    "HP24", Package()   //  USB3 port with hub (advanced dock)
                     {
-                        //"UsbConnector", 0,
+                        //"UsbConnector", 3,
                         "port", Buffer() { 4, 0, 0, 0 },
                     },
-                    "HP26", Package()   // unknown USB2 port (dock?)
+                    "HP26", Package()   // eSata/USB2 port left
                     {
                         //"UsbConnector", 0,
                         "port", Buffer() { 6, 0, 0, 0 },
@@ -117,13 +121,19 @@
                     // HS02 HS USB3 near left
                     // HS03 HS USB3 far left
                     // HS04 USB2 far right
-                    // SS05/SS06 not used
-                    "SS07", Package()   // SS USB3 left
+                    // SS05 USB3 advanced dock
+
+                    "SS05", Package()   // SS USB3 hub advanced dock
+                    {
+                        "UsbConnector", 3,
+                        "port", Buffer() { 5, 0, 0, 0 },
+                    },
+                    "SS07", Package()   // near display SS USB3 right
                     {
                         "UsbConnector", 3,
                         "port", Buffer() { 7, 0, 0, 0 },
                     },
-                    "SS08", Package()   // SS USB3 left
+                    "SS08", Package()   // far display SS USB3 right
                     {
                         "UsbConnector", 3,
                         "port", Buffer() { 8, 0, 0, 0 },


### PR DESCRIPTION
As the title says. The former SSDT-USB-8x70 version didn't work correctly for my EliteBook 8570p. 
One onboard usb2 port was not working (was EH01 Hub1 HP12). Also the USB3 Hub on the advanced dock was not injected.
Beside that all the comments were wrong too.

Not sure if this is really 8x70 generic or only 8570p.

For reference this is the ioreg for all notebook ports including the 4 usb2 ports on the normal dock:

https://www.dropbox.com/s/ryj9fdsoremxqnr/usb_normal_dock.ioreg?dl=0

and this is the ioreg from all usb2 and usb3 ports on the advanced dock:

https://www.dropbox.com/s/rv7ogt7hzea1h91/usb_advanced_dock.ioreg?dl=0
